### PR TITLE
Make vcf_to_aliquot input dataset files optional

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# pycharm
+.idea
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/aliquotmaf/subcommands/vcf_to_aliquot/runners/gdc_2_0_0_aliquot.py
+++ b/aliquotmaf/subcommands/vcf_to_aliquot/runners/gdc_2_0_0_aliquot.py
@@ -55,6 +55,8 @@ class GDC_2_0_0_Aliquot(BaseRunner):
             "hotspots": None,
             "gnomad": None,
             "entrez": None,
+            "entrez_gene_id": None,
+            "gnomad_noncancer": None
         }
 
         # Filters


### PR DESCRIPTION
Provide defaults so we don't get `KeyErrors` when attempting to set up annotators for entrez and gnomAD non-cancer datasets.