### PR TITLE
Patch chromosome property to string-ify int-like values

### DIFF
--- a/aliquotmaf/subcommands/vcf_to_aliquot/runners/gdc_2_0_0_aliquot.py
+++ b/aliquotmaf/subcommands/vcf_to_aliquot/runners/gdc_2_0_0_aliquot.py
@@ -1,12 +1,10 @@
 """Main vcf2maf logic for spec gdc-2.0.0-aliquot"""
 import urllib.parse
-from typing import List
 
 import pysam
 from maflib.header import MafHeader, MafHeaderRecord
-from maflib.locatable import Locatable
 from maflib.record import MafRecord
-from maflib.sort_order import BarcodesAndCoordinate, _CoordinateKey
+from maflib.sort_order import BarcodesAndCoordinate
 from maflib.sorter import MafSorter
 from maflib.validation import ValidationStringency
 from maflib.writer import MafWriter

--- a/aliquotmaf/subcommands/vcf_to_aliquot/runners/gdc_2_0_0_aliquot.py
+++ b/aliquotmaf/subcommands/vcf_to_aliquot/runners/gdc_2_0_0_aliquot.py
@@ -288,7 +288,6 @@ class GDC_2_0_0_Aliquot(BaseRunner):
                 return str(self["Chromosome"].value)
 
         MafRecord.chromosome = MonkeyMafRecord.chromosome
-        print(MafRecord.chromosome)
 
         try:
             # Validate samples

--- a/aliquotmaf/subcommands/vcf_to_aliquot/runners/gdc_2_0_0_aliquot.py
+++ b/aliquotmaf/subcommands/vcf_to_aliquot/runners/gdc_2_0_0_aliquot.py
@@ -1,9 +1,12 @@
 """Main vcf2maf logic for spec gdc-2.0.0-aliquot"""
 import urllib.parse
+from typing import List
 
 import pysam
 from maflib.header import MafHeader, MafHeaderRecord
-from maflib.sort_order import BarcodesAndCoordinate
+from maflib.locatable import Locatable
+from maflib.record import MafRecord
+from maflib.sort_order import BarcodesAndCoordinate, _CoordinateKey
 from maflib.sorter import MafSorter
 from maflib.validation import ValidationStringency
 from maflib.writer import MafWriter
@@ -278,6 +281,16 @@ class GDC_2_0_0_Aliquot(BaseRunner):
         tumor_sample_id = self.options["tumor_vcf_id"]
         normal_sample_id = self.options["normal_vcf_id"]
         is_tumor_only = self.options["tumor_only"]
+
+        # Patch some terrible typing issues on the MafRecord chromosome
+        class MonkeyMafRecord(MafRecord):
+            @property  # type: ignore
+            def chromosome(self):  # type: ignore
+                """Returns the chromosome name"""
+                return str(self["Chromosome"].value)
+
+        MafRecord.chromosome = MonkeyMafRecord.chromosome
+        print(MafRecord.chromosome)
 
         try:
             # Validate samples


### PR DESCRIPTION
<!--
Hi there. Thanks for submitting a pull request!

Please describe your changes in this PR description.
You can also include a link to an active Jira ticket that provides relevant context if there is one.

https://policies.zephyrai.bio/sdlc.html
-->
# Proposed Changes

<!--
**Jira ticket**: https://zephyrai.atlassian.net/browse/TICKET
-->

<!-- Don't forget to motivate your pull request! -->
The `InputCollection` -> `MafRecord` conversion is absolutely insane. This just patches the `.chromosome` return property for a MAF to always return a string. This is pretty ideal behavior in ~almost~ all cases because chromosome names are treated as strings everywhere else. 

This supports UCSC-style hg19 chromosome indicators (without the chr prefix).